### PR TITLE
Remove extra decimal check from number field

### DIFF
--- a/src/fields/TypeNumber.jsx
+++ b/src/fields/TypeNumber.jsx
@@ -73,12 +73,6 @@ const TypeNumber = ({
       setError('Only numbers are allowed');
       setIsValid(false);
     }
-    if (rules?.filter((item) => item.allowDecimal)?.length === 0) {
-      if (v && parseFloat(v) % 1 !== 0 && !isNaN(v)) {
-        setError('Decimal values are not allowed for this question');
-        setIsValid(false);
-      }
-    }
   };
 
   return (


### PR DESCRIPTION
`Decimal values are not allowed for this question` was coming twice as we have put check in number field and then there was validations on question fields which was causing it to show error message twice 
