### PR TITLE
chore: update Semaphore OS image to ubuntu2204

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,7 +4,7 @@ name: 'Akvo React Form'
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 global_job_config:
   secrets:
     - name: GCP


### PR DESCRIPTION
## Summary
- Update Semaphore CI `os_image` from `ubuntu2004` to `ubuntu2204`
- Ubuntu 20.04 was phased out by Semaphore in March 2026 — jobs using this image fail to allocate an agent

## Reference
- https://docs.semaphore.io/reference/machine-types