### PR TITLE
Add a manual CI trigger and build on PRs to any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
 name: Build
 
-# Confirm the library still builds on PRs into and pushes to the release
-# branches. Lint and unit tests are intentionally out of scope.
+# Confirm the library still builds on every pull request and on pushes to
+# the release branches. Lint and unit tests are intentionally out of scope.
 on:
   pull_request:
-    branches: [main, develop]
     types: [opened, reopened, synchronize]
   push:
     branches: [main, develop]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches: [main, develop]
+  # Allow manual runs from the Actions tab or `gh workflow run`, so a push
+  # whose dispatch GitHub silently dropped can be re-triggered without an
+  # otherwise-pointless commit.
+  workflow_dispatch:
 
 # Cancel an in-flight build when a newer commit lands on the same PR or branch,
 # so only the latest revision is verified. Grouping by ref keeps separate PRs

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,10 @@ name: Deploy demo to GitHub Pages
 on:
   push:
     branches: [main]
+  # Allow manual runs from the Actions tab or `gh workflow run`, so a push
+  # whose dispatch GitHub silently dropped can be re-triggered without an
+  # otherwise-pointless commit.
+  workflow_dispatch:
 
 # Permissions required by the official GitHub Pages deployment actions.
 permissions:


### PR DESCRIPTION
## Summary

Two small CI workflow fixes, prompted by a push to `main` (`08f3d59`) whose GitHub Actions runs never triggered. GitHub recorded the push event but created no workflow runs — every config precondition checked out, so the dispatch was dropped on GitHub's side.

## Changes

- **Add `workflow_dispatch` to `build.yml` and `deploy-pages.yml`.** When GitHub drops a dispatch like this, these workflows previously could only be re-run by pushing another commit, since neither offered a manual entry point. Now they can be re-triggered from the Actions tab or `gh workflow run`. (`publish` and `deploy-poc` are release-/poc-branch-scoped and left unchanged.)
- **Build on pull requests targeting any branch.** The `pull_request` trigger restricted the base to `main`/`develop`, so a PR targeting any other base (e.g. a stacked PR onto a feature branch) got no build. Dropped the base-branch filter. The `push` trigger stays scoped to the release branches.

## Note

`workflow_dispatch` only becomes available once these files land on the default branch, so it can't help re-trigger the already-dropped run on `08f3d59` — that still needs a fresh push to `main`.
